### PR TITLE
not x in changed to x not in

### DIFF
--- a/Scripts/Miscellaneous/Fake_news_web/feature.py
+++ b/Scripts/Miscellaneous/Fake_news_web/feature.py
@@ -21,7 +21,7 @@ def remove_punctuation_stopwords_lemma(sentence):
     lemmatizer = WordNetLemmatizer()
     sentence = re.sub(r"[^\w\s]", "", sentence)
     words = nltk.word_tokenize(sentence)  # tokenization
-    words = [w for w in words if not w in stop_words]
+    words = [w for w in words if w not in stop_words]
     for word in words:
         filter_sentence = (
             filter_sentence + " " + str(lemmatizer.lemmatize(word)).lower()

--- a/Scripts/Miscellaneous/Unwrap_video/unwrap.py
+++ b/Scripts/Miscellaneous/Unwrap_video/unwrap.py
@@ -4,7 +4,7 @@ import glob, os, sys, subprocess
 # process each video in media folder
 for video in glob.glob("media/*"):
     # only process videos, ignore generated images
-    if not "jpeg" in video:
+    if "jpeg" not in video:
         # get video resolution
         try:
             cwd = os.getcwd()


### PR DESCRIPTION
# Description

Changed instances of 'not x in' to 'x not in' as suggested in the issue FLK-E713 (Test for membership should be 'not in')

Fixes #FLK-E713

Replace `issue_no` in the above line, with the issue related to this PR.

## Type of change

Choosing one or more options from the following as per the nature of your Pull request.
- NOTE: *These boxes can be checked using **`[X]`***

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation Update

# Checklist:
Please tick all the boxes that are fulfilled by your Pull Request.

- [X] I have named my files and folder, according to this project's guidelines.
- [X] My code follows the style guidelines of this project.
- [X] My Pull Request has a descriptive title. (not a vague title like `Update index.md`)
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have created a helpful and easy to understand `README.md`, according to the given [`README_TEMPLATE.`](https://github.com/Python-World/Python_and_the_Web/blob/master/README_TEMPLATE.md)
- [ ] I have included a requirements.txt file (if external libraries are required.)
- [X] My changes do not produce any warnings.
- [ ] I have added a working sample/screenshot of the script.
